### PR TITLE
Ignore values out of range when calculating reviews

### DIFF
--- a/src/components/card-grid.js
+++ b/src/components/card-grid.js
@@ -6,6 +6,8 @@ import CourseReviewCard from './course-review-card.js';
 import { Grid } from 'semantic-ui-react';
 import NoResultsFound from './no-results-found.js';
 
+import getAverageRating from '../helpers/AverageRating.js';
+
 // This function creates the grid of course review cards
 const CardGrid = (props) => {
   const { courses, majors, activeMajorTags, activeTermTags, activePrefixTags, activeSort, query } = props;
@@ -44,31 +46,10 @@ const CardGrid = (props) => {
   };
 
   const getOverallRating = (course) => {
-    let total = 0;
-    let count = 0;
-    course.reviews.forEach((review) => {
-      total += review.rating['overall'];
-      count++;
-    });
-    if (count === 0) {
-      return <p>😢</p>;
-    }
-    const roundedAverage = Math.round(total / count * 10) / 10;
-    return roundedAverage.toFixed(1);
-  };
-
-  const getAverageRating = (course, ratingCategory) => {
-    let total = 0;
-    let count = 0;
-    course.reviews.forEach((review) => {
-      total += review.rating[ratingCategory];
-      count++;
-    });
-    if (count === 0) {
-      return 0;
-    }
-    const average = total / count;
-    return average.toFixed(1);
+    const rating = getAverageRating(course, 'overall');
+    // Since the minimum rating is 1, we can assume that if the average rating is 0,
+    // then there are no reviews for the course.
+    return rating > 0 ? rating : 'No reviews yet 😢';
   };
 
   // FILTER HELPER FUNCTIONS

--- a/src/helpers/AverageRating.js
+++ b/src/helpers/AverageRating.js
@@ -1,0 +1,21 @@
+const RATE_MIN = 1;
+const RATE_MAX = 5;
+
+const getAverageRating = (course, ratingCategory) => {
+  let sum = 0;
+  let count = 0;
+  course.reviews.forEach((review) => {
+    const rating = review.rating[ratingCategory];
+    if (rating >= RATE_MIN && rating <= RATE_MAX) {
+      sum += rating;
+      count++;
+    }
+  });
+  if (count === 0) {
+    return 0;
+  }
+  const average = sum / count;
+  return average.toFixed(1);
+};
+
+export default getAverageRating;

--- a/src/pages/course-page.js
+++ b/src/pages/course-page.js
@@ -13,6 +13,8 @@ import PlaceHolderReview from '../components/course-review/placeholder-reviews.j
 import BlankSvg from '../assets/illustrations/blank_canvas.svg';
 import ScrollButton from '../components/scroll-button.js';
 
+import getAverageRating from '../helpers/AverageRating.js';
+
 import '../styles/course-page.css';
 
 const CoursePage = (props) => {
@@ -58,17 +60,7 @@ const CoursePage = (props) => {
     history.push('/');
   };
   const getAverage = (ratingCategory) => {
-    let total = 0;
-    let count = 0;
-    course.reviews.forEach((review) => {
-      total += review.rating[ratingCategory];
-      count++;
-    });
-    if (count === 0) {
-      return 0;
-    }
-    const average = total / count;
-    return average.toFixed(1);
+    return getAverageRating(course, ratingCategory);
   };
 
 


### PR DESCRIPTION
As much some courses deserve negative ratings (ahem ethics), I'd rather we not get flamed by CSE. This has also been reinforced by Firestore security rules.﻿
